### PR TITLE
Vandal Minor State Fix

### DIFF
--- a/history/states/1-France.txt
+++ b/history/states/1-France.txt
@@ -1,0 +1,26 @@
+
+state={
+	id=1
+	name="STATE_1" # Corsica
+	manpower = 322900
+	
+	state_category = town
+
+	history={
+		owner = VAN
+		victory_points = { 3838 1 }
+		buildings = {
+			infrastructure = 4
+			industrial_complex = 1
+			air_base = 1
+			3838 = {
+				naval_base = 3
+			}
+		}
+		add_core_of = VAN
+	}
+
+	provinces={
+		3838 9851 11804 
+	}
+}

--- a/history/states/116-Malta.txt
+++ b/history/states/116-Malta.txt
@@ -1,0 +1,23 @@
+state=
+{
+	id=116
+	name="STATE_116"
+	manpower = 241621
+	state_category = small_island
+	history= {
+		owner = VAN
+		add_core_of = VAN
+		victory_points = {
+			12003 5 
+		}
+		buildings = {
+			infrastructure = 3
+			air_base = 3
+			12003 = {
+				naval_base = 3
+				coastal_bunker = 1
+			}
+		}
+	}
+	provinces= { 12003 }
+}

--- a/history/states/177-Balearic Islands.txt
+++ b/history/states/177-Balearic Islands.txt
@@ -1,0 +1,27 @@
+state=
+{
+	id=177
+	name="STATE_177"
+	manpower = 365500
+	
+	state_category = rural
+	
+	history=
+	{
+		owner = VAN
+		buildings = {
+			infrastructure = 6
+			air_base = 1
+			9793 = {
+				naval_base = 2
+			}
+			7114 = {
+				naval_base = 1
+			}
+		}
+		add_core_of = VAN
+	}
+	provinces=
+	{
+7114 9793 9845 	}
+}

--- a/history/states/763-Marsala.txt
+++ b/history/states/763-Marsala.txt
@@ -1,0 +1,14 @@
+state={
+	id=763
+	name="STATE_763"
+	provinces={
+		7059 
+	}
+	manpower=1281
+	state_category = town
+	history= {
+		owner = VAN
+		add_core_of = VAN
+		}
+	}
+}


### PR DESCRIPTION
The vandals have been given Malta, the Balearic islands, and a small portion of Sicily (which is a custom state called Marsala), the only known bugs is that releasing the vandals as a puppet makes the game crash, this may be due to Sicily still having the province code but ill fix it in the future.